### PR TITLE
12 continue in repeat loops unexpected output

### DIFF
--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -184,6 +184,8 @@ impl Interpreter {
                 self.loop_stack.push(LoopControl::default());
 
                 while !Self::is_truthy(&self.expr(&repeat_until.condition)?) {
+                    self.stmt(&repeat_until.body)?;
+                    
                     // if the BREAK stmt was called handle it
                     if self.loop_stack.last().unwrap().should_break {
                         self.loop_stack.last_mut().unwrap().should_break = false;
@@ -196,7 +198,6 @@ impl Interpreter {
                         continue;
                     }
 
-                    self.stmt(&repeat_until.body)?;
                 }
 
                 // exit the loop
@@ -241,7 +242,7 @@ impl Interpreter {
                     self.venv
                         .define(element.clone(), values.borrow()[i].clone());
                     // execute body
-                    
+
                     
                     self.stmt(&for_each.body)?;
 
@@ -256,7 +257,7 @@ impl Interpreter {
                         self.loop_stack.last_mut().unwrap().should_continue = false;
                         continue;
                     }
-                    
+
                     // get temp val out and change it in vec
                     (*values.borrow_mut())[i] = self.venv.remove(element.clone()).unwrap().0;
                 }

--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -145,8 +145,8 @@ impl Interpreter {
                         self.loop_stack.push(LoopControl::default());
 
                         // floor the value into an int so we can iterate
-                        let count = count as usize;
-                        for _ in 1..=count {
+                        let mut iter = 1..=count as usize;
+                        for _ in iter {
                             // if the BREAK stmt was called handle it
                             if self.loop_stack.last().unwrap().should_break {
                                 self.loop_stack.last_mut().unwrap().should_break = false;
@@ -241,23 +241,22 @@ impl Interpreter {
                     self.venv
                         .define(element.clone(), values.borrow()[i].clone());
                     // execute body
-
-                    // handle break and continue
+                    
+                    
+                    self.stmt(&for_each.body)?;
 
                     // if the BREAK stmt was called handle it
                     if self.loop_stack.last().unwrap().should_break {
                         self.loop_stack.last_mut().unwrap().should_break = false;
                         break;
                     }
-
+                    // handle break and continue
                     // if the CONTINUE stmt was called then we need to deal with that
                     if self.loop_stack.last().unwrap().should_continue {
                         self.loop_stack.last_mut().unwrap().should_continue = false;
                         continue;
                     }
-
-                    // todo possible bug: confirm that this doesnt have any weird value errors
-                    self.stmt(&for_each.body)?;
+                    
                     // get temp val out and change it in vec
                     (*values.borrow_mut())[i] = self.venv.remove(element.clone()).unwrap().0;
                 }

--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -145,21 +145,20 @@ impl Interpreter {
                         self.loop_stack.push(LoopControl::default());
 
                         // floor the value into an int so we can iterate
-                        let mut iter = 1..=count as usize;
-                        for _ in iter {
-                            // if the BREAK stmt was called handle it
-                            if self.loop_stack.last().unwrap().should_break {
-                                self.loop_stack.last_mut().unwrap().should_break = false;
-                                break;
-                            }
+                        for _ in 1..=count as usize {
+                            self.stmt(&repeat_times.body)?;
 
                             // if the CONTINUE stmt was called handle it
                             if self.loop_stack.last().unwrap().should_continue {
                                 self.loop_stack.last_mut().unwrap().should_continue = false;
                                 continue;
                             }
-
-                            self.stmt(&repeat_times.body)?;
+                            
+                            // if the BREAK stmt was called handle it
+                            if self.loop_stack.last().unwrap().should_break {
+                                self.loop_stack.last_mut().unwrap().should_break = false;
+                                break;
+                            }
                         }
 
                         // exit the loop

--- a/tests/root.rs
+++ b/tests/root.rs
@@ -529,13 +529,13 @@ fn test_loop_break() {
 #[test]
 fn test_continue_in_repeat_loop() {
     smart_test(r#"
-    counter <- 1
+    counter <- 0
     REPEAT 10 TIMES {
-        DISPLAY(counter)
         counter <- counter + 1
         IF (counter == 5 OR counter == 7) {
             CONTINUE
         }
+        DISPLAY(counter)
     }
     $1
     $2
@@ -592,7 +592,7 @@ fn test_nested_break_in_loops() {
             IF (innerCounter == 3) {
                 BREAK
             }
-            DISPLAY(outerCounter + "-" + innerCounter)
+            DISPLAY("" + outerCounter + "-" + innerCounter)
         }
     }
     $1-1
@@ -616,7 +616,7 @@ fn test_nested_continue_in_loops() {
             IF (innerCounter == 2) {
                 CONTINUE
             }
-            DISPLAY(outerCounter + "-" + innerCounter)
+            DISPLAY("" + outerCounter + "-" + innerCounter)
         }
     }
     $1-1


### PR DESCRIPTION
Fix #12

`CONTINUE` now properly works in `REPEAT` style loops